### PR TITLE
Silence reading zero-length messages from language server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 [dependencies]
 serde_json = "1.0"
 jsonrpc-lite = "0.6"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,7 +29,7 @@ use std::thread;
 use jsonrpc_lite::JsonRpc as JsonRPC;
 use serde_json::{self, value::Value};
 
-use crate::parsing;
+use crate::parsing::{self, ParseError};
 
 // this to get around some type system pain related to callbacks. See:
 // https://doc.rust-lang.org/beta/book/trait-objects.html,
@@ -218,7 +218,8 @@ pub fn start_language_server(mut child: Child) -> (Child, LanguageServerRef<Chil
             loop {
                 match parsing::read_message(&mut reader) {
                     Ok(ref val) => lang_server.handle_msg(val),
-                    Err(err) => println!("parse error: {:?}", err),
+                    Err(ParseError::Empty) => (),
+                    Err(err) => eprintln!("parse error: {:?}", err),
                 };
             }
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use lsp_client::start_language_server;
 use std::process::{Child, Command, Stdio};
 
 /// An example of how to interact with a language server.
+#[cfg(not(tarpaulin_include))]
 fn main() {
     let (mut child, lang_server) = start_language_server(prepare_command());
     let init = json!({
@@ -49,6 +50,7 @@ fn main() {
     let _ = child.wait();
 }
 
+#[cfg(not(tarpaulin_include))]
 fn prepare_command() -> Child {
     Command::new("rust-analyzer")
         .stdin(Stdio::piped())

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -46,6 +46,7 @@ pub enum ParseError {
     Io(io::Error),
     ParseInt(std::num::ParseIntError),
     Utf8(std::string::FromUtf8Error),
+    Encoding(String),
     Json(serde_json::Error),
     Unknown(String),
 }
@@ -127,7 +128,20 @@ fn parse_header(s: &str) -> Result<LspHeader, ParseError> {
         return Err(ParseError::Unknown(format!("malformed header: {}", s)));
     }
     match split[0].as_ref() {
-        HEADER_CONTENT_TYPE => Ok(LspHeader::ContentType),
+        HEADER_CONTENT_TYPE => {
+            let encoding = split[1].to_lowercase();
+            let is_valid_encoding = ["utf-8", "utf8"]
+                .iter()
+                .any(|valid_encoding| *valid_encoding == encoding);
+            if is_valid_encoding {
+                Ok(LspHeader::ContentType)
+            } else {
+                Err(ParseError::Encoding(format!(
+                    "Invalid encoding: {}",
+                    split[1]
+                )))
+            }
+        }
         HEADER_CONTENT_LENGTH => Ok(LspHeader::ContentLength(split[1].parse()?)),
         _ => Err(ParseError::Unknown(format!("Unknown header: {}", s))),
     }
@@ -139,12 +153,32 @@ mod tests {
     use std::io::BufReader;
 
     #[test]
-    fn test_parse_header() {
+    fn test_parse_header_content_length() {
         let header = "Content-Length: 132";
         assert_eq!(
             parse_header(header).ok(),
             Some(LspHeader::ContentLength(132))
         );
+    }
+
+    #[test]
+    fn test_parse_header_content_type() {
+        let header = "Content-Type: utf-8";
+        let parsed = parse_header(header);
+        assert_eq!(parsed.ok(), Some(LspHeader::ContentType));
+
+        // For backwards compatibility; see
+        // https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#contentPart
+        let header = "Content-Type: utf8";
+        let parsed = parse_header(header);
+        assert_eq!(parsed.ok(), Some(LspHeader::ContentType));
+    }
+
+    #[test]
+    fn test_parse_header_invalid_content_type() {
+        let header = "Content-Type: ascii";
+        let parsed = parse_header(header);
+        assert!(parsed.is_err());
     }
 
     #[test]
@@ -194,8 +228,6 @@ mod tests {
             "Content-length: 18\n\r\n\r{\"name\": \"value\"}",
             "Content-Length: 18\n\rContent-Type: utf-8\n\r\n\r{\"name\": \"value\"}",
             "Content-Length: 18\n\rContent-Type: utf-8\n\r\n\r{\"name\": \"value\"}\n",
-            // FIXME this should fail due to invalid encoding
-            "Content-Length: 18\n\rContent-Type: ascii\n\r\n\r{\"name\": \"value\"}",
         ];
         for inp in inps {
             let mut reader = BufReader::new(inp.as_bytes());
@@ -205,6 +237,33 @@ mod tests {
             };
             let exp = json!({"name": "value"});
             assert_eq!(result, exp);
+        }
+    }
+
+    #[test]
+    fn test_read_message_invalid_content_type() {
+        let test_cases = [
+            (
+                "Content-Length: 18\n\rContent-Type: ascii\n\r\n\r{\"name\": \"value\"}",
+                "Invalid encoding: ascii",
+            ),
+            (
+                "Content-Length: 18\n\rContent-Type: utf-9\n\r\n\r{\"name\": \"hello\"}",
+                "Invalid encoding: utf-9",
+            ),
+        ];
+        for (inp, err_msg) in test_cases {
+            let mut reader = BufReader::new(inp.as_bytes());
+            let result = match read_message(&mut reader) {
+                Ok(r) => panic!("unexpected success: {:#?}", r),
+                Err(e) => match e {
+                    ParseError::Encoding(s) => {
+                        assert_eq!(s, err_msg.to_string())
+                    }
+                    default => panic!("incorrect ParseError variant: {:#?}", default),
+                },
+            };
+            assert_eq!(result, ());
         }
     }
 


### PR DESCRIPTION
1. I can't quickly figure out why there are lots of zero-length messages being produced by reading from the language server standard output.  Swallow them for now.
2. Disallow anything other than UTF-8 or unspecified content encodings.